### PR TITLE
Add kc-sf-plugin to list of 3rd party plugins in marketplace

### DIFF
--- a/src/shared/plugins.ts
+++ b/src/shared/plugins.ts
@@ -27,4 +27,5 @@ export const packages = [
   'sfdx-plugin-update-notifier',
   '@cristiand391/sf-plugin-api',
   '@cristiand391/sf-plugin-fzf-cmp',
+  'kc-sf-plugin',
 ];


### PR DESCRIPTION
### What does this PR do?
- Add my own personal sf cli plugin to the list of discoverable plugins
- For reference: https://github.com/k-capehart/kc-sf-plugin
