### PR TITLE
fix: remove `sf-plugin-api`

### DIFF
--- a/src/shared/plugins.ts
+++ b/src/shared/plugins.ts
@@ -25,7 +25,6 @@ export const packages = [
   '@jayree/sfdx-plugin-prettier',
   '@jayree/sfdx-plugin-source',
   'sfdx-plugin-update-notifier',
-  '@cristiand391/sf-plugin-api',
   '@cristiand391/sf-plugin-fzf-cmp',
   'kc-sf-plugin',
 ];


### PR DESCRIPTION
### What does this PR do?

Removes my plugin, I've already deprecated it:
https://github.com/cristiand391/sf-plugin-api?tab=readme-ov-file#%EF%B8%8F-deprecated-%EF%B8%8F

### What issues does this PR fix or reference?
[skip-validate-pr]
