### PR TITLE
feature: crm analytics connect-objects plugin added

### DIFF
--- a/src/shared/plugins.ts
+++ b/src/shared/plugins.ts
@@ -35,4 +35,5 @@ export const packages = [
   'sfdx-plugin-update-notifier',
   '@cristiand391/sf-plugin-fzf-cmp',
   'kc-sf-plugin',
+  'plugin-analytics-connected-objects'
 ];


### PR DESCRIPTION
### What does this PR do?

- Include an additional plugin in the list shown while executing the discover command

<img width="1356" height="73" alt="image" src="https://github.com/user-attachments/assets/009b9c1e-1c4f-47e0-9d93-b61afe0d3c21" />


### What issues does this PR fix or reference?
- None